### PR TITLE
Engine plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,2 @@
 npm-debug.log
 node_modules
-.DS_Store
-.*.sw[op]
-*.log
-*~

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+npm-debug.log
+node_modules
+.DS_Store
+.*.sw[op]
+*.log
+*~

--- a/lib/viewful.js
+++ b/lib/viewful.js
@@ -92,10 +92,11 @@ View.prototype.render = function (data, callback) {
       outputEngine = viewful.engines[self.output];
   
   if (callback) {
-    return inputEngine.render(self, data, callback);
+    return inputEngine.render(self.template, data, callback);
   }
 
-  return inputEngine.render(self, data);
+  return inputEngine.render(self.template, data);
+
   /*
   //
   // check for layout file

--- a/package.json
+++ b/package.json
@@ -3,9 +3,14 @@
   "name": "viewful",
   "version": "0.0.0",
   "dependencies": {
-    "utile": "0.0.10"
+    "utile": "0.0.10",
+    "cheerio": "0.9.x"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "vows": "*",
+    "broadway": "*",
+    "jade": "*"
+  },
   "optionalDependencies": {},
   "engines": {
     "node": "*"

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -4,8 +4,8 @@ var assert = require('assert');
 helpers.render = function (data, expected) {
   expected = expected || '';
   return {
-    topic: function(_view){
-      this.callback(null, _view.render(data));
+    topic: function (_view) {
+      _view.render(data, this.callback);
     },
     'should compile expected result' : function (err, result) {
       assert.equal(result, expected);


### PR DESCRIPTION
Fix bug for inputEngine.render() method on main viewful.js script. It needs to be passed self.template param instead of self param, in order to pass one of the existing tests in viewful-engines-test.js.
