### PR TITLE
[fix] Fix first param for jade.compile().

### DIFF
--- a/lib/engines/jade/index.js
+++ b/lib/engines/jade/index.js
@@ -10,11 +10,11 @@ exports.jade = function(path, options, fn){
 exports.attach = function (options) {
   var jade = require("jade");
   this.jade = {
-    render : function(template, data, cb){
+    render : function (view, data, cb){
       if (cb) {
-        return cb(null, jade.compile(template)(data));
+        return cb(null, jade.compile(view.template)(data));
       }
-      return jade.compile(template)(data);
+      return jade.compile(view.template)(data);
     }
   }
 };


### PR DESCRIPTION
Fix the first parameter for jade.compile() in the jade engine plugin. Compile method expects a template string, not a complete view object.
